### PR TITLE
defaulting to ecfp4

### DIFF
--- a/bblean/analysis.py
+++ b/bblean/analysis.py
@@ -48,7 +48,7 @@ class ClusterAnalysis:
 
 # Get the number of unique scaffolds and the scaffold isim
 def scaffold_analysis(
-    smiles: tp.Iterable[str], fp_kind: str = "rdkit"
+    smiles: tp.Iterable[str], fp_kind: str = "ecfp4"
 ) -> ScaffoldAnalysis:
     r"""Perform a scaffold analysis of a sequence of smiles"""
     if isinstance(smiles, str):
@@ -69,7 +69,7 @@ def cluster_analysis(
     n_features: int | None = None,
     top: int = 20,
     assume_sorted: bool = True,
-    scaffold_fp_kind: str = "rdkit",
+    scaffold_fp_kind: str = "ecfp4",
     input_is_packed: bool = True,
 ) -> ClusterAnalysis:
     r"""Perform a cluster analysis starting from clusters, smiles, and fingerprints"""

--- a/bblean/cli.py
+++ b/bblean/cli.py
@@ -98,7 +98,7 @@ def _summary_plot(
     scaffold_fp_kind: Annotated[
         str,
         Option("--scaffold-fp-kind"),
-    ] = "rdkit",
+    ] = "ecfp4",
     n_features: Annotated[
         int | None,
         Option(
@@ -594,7 +594,7 @@ def _fps_from_smiles(
     kind: Annotated[
         str,
         Option("-k", "--kind"),
-    ] = "rdkit",
+    ] = "ecfp4",
     fp_size: Annotated[
         int,
         Option("--n-features", help="Num. features of the generated fingerprints"),

--- a/bblean/fingerprints.py
+++ b/bblean/fingerprints.py
@@ -96,7 +96,7 @@ def _get_generator(kind: str, n_features: int) -> tp.Any:
 
 def fps_from_smiles(
     smiles: tp.Iterable[str],
-    kind: str = "rdkit",
+    kind: str = "ecfp4",
     n_features: int = DEFAULTS.n_features,
     dtype: DTypeLike = np.uint8,
     pack: bool = True,

--- a/examples/bitbirch_quickstart.ipynb
+++ b/examples/bitbirch_quickstart.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "383bef0c-2b46-4d78-b929-4814bfe18c43",
    "metadata": {
     "tags": []
@@ -85,7 +85,7 @@
    "source": [
     "smiles = bblean.load_smiles(\"./chembl-sample.smi\", max_num=5000)\n",
     "\n",
-    "# By default the fps created are of the \"rdkit\" kind\n",
+    "# By default the fps created are of the \"ecfp4\" kind\n",
     "fps = bblean.fps_from_smiles(smiles, pack=True, n_features=2048)\n",
     "print(f\"Shape: {fps.shape}, DType: {fps.dtype}\")"
    ]


### PR DESCRIPTION
Rdkit fingerprints are causing ~10-30x slowdown over ecfp4. This PR changes the default fingerprint type to ecfp4. 

```
% time bb fps-from-smiles examples/chembl-sample-3k.smi
Finished. Outputs written to /Volumes/T7_Shield/Github/bblean/packed-fps-uint8-93dda576.npy
bb fps-from-smiles examples/chembl-sample-3k.smi  0.60s user 0.06s system 69% cpu 0.957 total

% time bb fps-from-smiles examples/chembl-sample-3k.smi --kind rdkit
Finished. Outputs written to /Volumes/T7_Shield/Github/bblean/packed-fps-uint8-e7035d22.npy
bb fps-from-smiles examples/chembl-sample-3k.smi --kind rdkit  7.44s user 0.10s system 98% cpu 7.622 total
```

More detailed stats (on 10K smiles)

```
% python benchmark_pack.py chembl_33_10K.smi --kind ecfp4

Molecules processed: 10000
Fingerprint size: 2048 bits
Array dtype: uint8
Generator: ecfp4

Generate bit vectors     avg=0.3682s  best=0.3592s  throughput=27158.1 fps/s
Convert to NumPy         avg=0.2791s  best=0.2779s  throughput=35828.1 fps/s
Pack fingerprints        avg=0.0010s  best=0.0009s  throughput=10296893.7 fps/s

% python benchmark_pack.py chembl_33_10K.smi --kind rdkit
Molecules processed: 10000
Fingerprint size: 2048 bits
Array dtype: uint8
Generator: rdkit

Generate bit vectors     avg=26.4743s  best=26.3842s  throughput=377.7 fps/s
Convert to NumPy         avg=0.3167s  best=0.3154s  throughput=31572.5 fps/s
Pack fingerprints        avg=0.0012s  best=0.0009s  throughput=8453087.8 fps/s
```
