### PR TITLE
feature/ipickering/improve memory efficiency

### DIFF
--- a/bblean/_config.py
+++ b/bblean/_config.py
@@ -22,7 +22,6 @@ class BitBirchConfig:
     merge_criterion: str = "diameter"
     tolerance: float = 0.05
     n_features: int = 2048
-    use_mmap: bool = True
     fp_kind: str = "ecfp4"
 
 

--- a/bblean/_console.py
+++ b/bblean/_console.py
@@ -76,7 +76,6 @@ class BBConsole(Console):
                 f"- Threshold: {config['threshold']}\n"
                 f"- Num. files loaded: {len(config['input_files']):,}\n"
                 f"- Num. fingerprints loaded for each file: {num_fps_str}\n"
-                f"- Use mmap: {config['use_mmap']}\n"
                 f"- Output directory: {config['out_dir']}\n",
                 end="",
             )
@@ -122,7 +121,6 @@ class BBConsole(Console):
                 f"- Tolerance: {config['tolerance']}\n"
                 f"- Num. files loaded: {len(config['input_files']):,}\n"
                 f"- Num. fingerprints loaded for each file: {num_fps_str}\n"
-                f"- Use mmap: {config['use_mmap']}\n"
                 f"- Output directory: {config['out_dir']}\n",
                 end="",
             )

--- a/bblean/_memory.py
+++ b/bblean/_memory.py
@@ -85,7 +85,7 @@ class _ArrayMemPagesManager:
     _curr_page_start_addr: int
 
     @classmethod
-    def from_array(cls, X: _Input) -> tpx.Self:
+    def from_bb_input(cls, X: _Input, can_release: bool | None = None) -> tpx.Self:
         pagesizex = mmap.PAGESIZE * 512
         if (
             isinstance(X, np.memmap)
@@ -97,12 +97,14 @@ class _ArrayMemPagesManager:
             # Every n_iters, release the prev page and add pagesizex to start_addr
             iters_per_pagex = int(pagesizex / X.shape[1])  # ~ 8192 iterations
             curr_page_start_addr = X.ctypes.data - X.offset
-            can_release = True
+            _can_release = True
         else:
             iters_per_pagex = 0
             curr_page_start_addr = 0
-            can_release = False
-        return cls(can_release, pagesizex, iters_per_pagex, curr_page_start_addr)
+            _can_release = False
+        if can_release is not None:
+            _can_release = can_release
+        return cls(_can_release, pagesizex, iters_per_pagex, curr_page_start_addr)
 
     def should_release_curr_page(self, row_idx: int) -> bool:
         return row_idx % self._iters_per_pagex == 0

--- a/bblean/_memory.py
+++ b/bblean/_memory.py
@@ -1,5 +1,10 @@
 r"""Monitor and collect memory stats"""
 
+import typing as tp
+import mmap
+import warnings
+from enum import Enum
+import ctypes
 import dataclasses
 from pathlib import Path
 import sys
@@ -7,7 +12,10 @@ import time
 import os
 import multiprocessing as mp
 
+import typing_extensions as tpx
 import psutil
+import numpy as np
+from numpy.typing import NDArray
 from rich.console import Console
 
 try:
@@ -18,6 +26,106 @@ except Exception:
 
 
 _BYTES_TO_GIB = 1 / 1024**3
+
+
+class Madv(Enum):
+    WILLNEED = 3
+    SEQUENTIAL = 2
+    # PAGEOUT and DONTNEED reduce memory usage around 40%
+    # TODO: Check exactly what DONTNEED does. I believe PAGEOUT *swaps out*
+    # so DONTNEED may be preferred since it may have less perf. penalty
+    DONTNEED = 4
+    PAGEOUT = 21
+    FREE = 8  # *ONLY* works on anonymous pages (not file-backed like numpy arrays)
+    # Cold does *not* immediatly release memory, it is just a soft hint that
+    # those pages won't be needed soon
+    COLD = 20
+
+
+# Get handle to the system's libc
+def _get_libc() -> tp.Any:
+    if sys.platform == "linux":
+        return ctypes.CDLL("libc.so.6", use_errno=True)
+    elif sys.platform == "darwin":
+        return ctypes.CDLL("libc.dylib", use_errno=True)
+    # For now, do nothing in Windows
+    return
+
+
+# This reduces memory usage around 40%, since the kernel can release
+# pages once the array has been iterated over. The issue is, after this has been done,
+# the array is out of the RAM, so refinement is not possible.
+def _madvise_dontneed(page_start: int, size: int) -> None:
+    _madvise(page_start, size, Madv.DONTNEED)
+
+
+# let the kernel know that access to this range of addrs will be sequential
+# (pages can be read-ahead and discarded fast after read if needed)
+def _madvise_sequential(page_start: int, size: int) -> None:
+    _madvise(page_start, size, Madv.SEQUENTIAL)
+
+
+def _madvise(page_start: int, size: int, opt: Madv) -> None:
+    libc = _get_libc()
+    if libc is None:
+        return
+    if libc.madvise(ctypes.c_void_p(page_start), size, opt.value) != 0:
+        errno = ctypes.get_errno()
+        warnings.warn(f"{opt} failed with error code {errno}")
+
+
+_Input = tp.Union[NDArray[np.integer], list[NDArray[np.integer]]]
+
+
+@dataclasses.dataclass
+class _ArrayMemPagesManager:
+    can_release: bool
+    _pagesizex: int
+    _iters_per_pagex: int
+    _curr_page_start_addr: int
+
+    @classmethod
+    def from_array(cls, X: _Input) -> tpx.Self:
+        pagesizex = mmap.PAGESIZE * 512
+        if (
+            isinstance(X, np.memmap)
+            and X.ndim == 2
+            and (pagesizex % X.shape[1] == 0)
+            and X.offset < X.shape[1]
+        ):
+            # In most cases pagesizex % n_features == 0 and offset < n_features
+            # Every n_iters, release the prev page and add pagesizex to start_addr
+            iters_per_pagex = int(pagesizex / X.shape[1])  # ~ 8192 iterations
+            curr_page_start_addr = X.ctypes.data - X.offset
+            can_release = True
+        else:
+            iters_per_pagex = 0
+            curr_page_start_addr = 0
+            can_release = False
+        return cls(can_release, pagesizex, iters_per_pagex, curr_page_start_addr)
+
+    def should_release_curr_page(self, row_idx: int) -> bool:
+        return row_idx % self._iters_per_pagex == 0
+
+    def release_curr_page_and_update_addr(self) -> None:
+        _madvise_dontneed(self._curr_page_start_addr, self._pagesizex)
+        self._curr_page_start_addr += self._pagesizex
+
+
+def _mmap_file_and_madvise_sequential(
+    path: Path, max_fps: int | None = None
+) -> NDArray[np.integer]:
+    arr = np.load(path, mmap_mode="r")[:max_fps]
+    # Numpy actually puts the *whole file* in mmap mode (arr + header)
+    # This means the array data starts from a nonzero offset starting from the backing
+    # buffer if we want the address to the start of the file we need to displace the
+    # addr of the arry by the bsize of the header, which can be accessed by arr.offset
+    #
+    # This is required since madvise needs a page-aligned address (address must
+    # be a multiple of mmap.PAGESIZE (portable) == os.sysconf("SC_PAGE_SIZE")
+    # (mac|linux), typically 4096 B).
+    _madvise_sequential(arr.ctypes.data - arr.offset, arr.nbytes)
+    return arr
 
 
 def system_mem_gib() -> tuple[int, int] | tuple[None, None]:

--- a/bblean/_merges.py
+++ b/bblean/_merges.py
@@ -153,6 +153,6 @@ def get_merge_accept_fn(
     elif merge_criterion == "tolerance_tough":
         return ToleranceToughMerge(tolerance)
     raise ValueError(
-        f"Unknown merge criterion {merge_criterion}"
+        f"Unknown merge criterion {merge_criterion} "
         "Valid criteria are: radius|diameter|tolerance|tolerance_tough"
     )

--- a/bblean/cli.py
+++ b/bblean/cli.py
@@ -306,8 +306,20 @@ def _run(
         )
     with console.status("[italic]BitBirching...[/italic]", spinner="dots"):
         for file in input_files:
-            fps = np.load(file, mmap_mode="r" if use_mmap else None)[:max_fps]
-            tree.fit(fps, n_features=n_features, input_is_packed=input_is_packed)
+            if use_mmap:
+                # fit_file uses mmap internally, and releases memory in a smart way
+                tree.fit_file(
+                    file,
+                    n_features=n_features,
+                    input_is_packed=input_is_packed,
+                    max_fps=max_fps,
+                )
+            else:
+                tree.fit(
+                    np.load(file)[:max_fps],
+                    n_features=n_features,
+                    input_is_packed=input_is_packed,
+                )
 
         # TODO: Fix peak memory stats
         cluster_mol_ids = tree.get_cluster_mol_ids()

--- a/bblean/cli.py
+++ b/bblean/cli.py
@@ -12,7 +12,6 @@ import multiprocessing as mp
 from typing import Annotated
 from pathlib import Path
 
-import numpy as np
 from typer import Typer, Argument, Option, Abort, Context, Exit
 
 from bblean._memory import launch_monitor_rss_daemon, get_peak_memory
@@ -80,10 +79,6 @@ def _summary_plot(
     clusters_path: Annotated[Path, Option("-c", "--clusters-path", show_default=False)],
     fps_path: Annotated[Path, Option("-f", "--fps-path", show_default=False)],
     smiles_path: Annotated[Path, Option("-s", "--smiles-path", show_default=False)],
-    use_mmap: Annotated[
-        bool,
-        Option("--use-mmap/--no-use-mmap"),
-    ] = True,
     title: Annotated[
         str | None,
         Option("--title"),
@@ -122,6 +117,7 @@ def _summary_plot(
     # Imports may take a bit of time since sklearn is slow, so start the spinner here
     with console.status("[italic]Analyzing clusters...[/italic]", spinner="dots"):
         import matplotlib.pyplot as plt
+        import numpy as np
 
         from bblean.smiles import load_smiles
         from bblean.analysis import cluster_analysis
@@ -131,7 +127,7 @@ def _summary_plot(
             clusters_path = clusters_path / "clusters.pkl"
         with open(clusters_path, mode="rb") as f:
             clusters = pickle.load(f)
-        fps = np.load(fps_path, mmap_mode="r" if use_mmap else None)
+        fps = np.load(fps_path, mmap_mode="r")
         smiles = load_smiles(smiles_path)
         ca = cluster_analysis(
             clusters,
@@ -195,13 +191,6 @@ def _run(
             ),
         ),
     ] = 0,
-    use_mmap: Annotated[
-        bool,
-        Option(
-            help="Toggle mmap of the fingerprint files (True recommended)",
-            rich_help_panel="Advanced",
-        ),
-    ] = DEFAULTS.use_mmap,
     n_features: Annotated[
         int | None,
         Option(
@@ -259,7 +248,6 @@ def _run(
 ) -> None:
     r"""Run standard, serial BitBIRCH clustering over `*.npy` fingerprint files"""
     # TODO: Remove code duplication with multiround
-    import numpy as np
     from bblean._console import get_console
     from bblean.fingerprints import _get_fps_file_num
 
@@ -316,26 +304,17 @@ def _run(
             merge_criterion=merge_criterion,
             tolerance=tolerance,
         )
+    if len(input_files) > 0 and refine_num > 0:
+        console.print("Refine currently only supported for single files", style="red")
+        raise Abort()
     with console.status("[italic]BitBirching...[/italic]", spinner="dots"):
         for file in input_files:
-            if use_mmap:
-                # fit_file uses mmap internally, and releases memory in a smart way
-                tree.fit_file(
-                    file,
-                    n_features=n_features,
-                    input_is_packed=input_is_packed,
-                    max_fps=max_fps,
-                )
-            else:
-                tree.fit(
-                    np.load(file)[:max_fps],
-                    n_features=n_features,
-                    input_is_packed=input_is_packed,
-                )
+            # Fitting a file uses mmap internally, and releases memory in a smart way
+            tree.fit(file, n_features, input_is_packed=input_is_packed, max_fps=max_fps)
 
         if refine_num > 0:
             tree.refine_inplace(
-                fps, input_is_packed=input_is_packed, n_largest=refine_num
+                file, input_is_packed=input_is_packed, n_largest=refine_num
             )
         # TODO: Fix peak memory stats
         cluster_mol_ids = tree.get_cluster_mol_ids()
@@ -446,13 +425,6 @@ def _multiround(
     max_tasks_per_process: Annotated[
         int, Option(help="Max tasks per process", rich_help_panel="Advanced")
     ] = 1,
-    use_mmap: Annotated[
-        bool,
-        Option(
-            help="Toggle mmap of the fingerprint files (True recommended)",
-            rich_help_panel="Advanced",
-        ),
-    ] = DEFAULTS.use_mmap,
     fork: Annotated[
         bool,
         Option(
@@ -569,7 +541,6 @@ def _multiround(
         tolerance=tolerance,
         # Advanced
         bin_size=bin_size,
-        use_mmap=use_mmap,
         max_tasks_per_process=max_tasks_per_process,
         double_cluster_init=double_cluster_init,
         # Debug
@@ -821,6 +792,7 @@ def _split_fps(
     number of parts (e.g. 10) `bb split-fps --num-parts 10 ./fps.npy --out-dir ./split`.
     """
     from bblean._console import get_console
+    import numpy as np
 
     console = get_console()
     if parts is not None and parts < 2:

--- a/bblean/multiround.py
+++ b/bblean/multiround.py
@@ -169,6 +169,13 @@ class _InitialRound:
             threshold=self.threshold,
             merge_criterion=self.merge_criterion,
         )
+        # TODO: It is possible to use madvise here, similarly to fit_file() It is
+        # *not easy* though. Maybe best would be to invalidate the mmap completely and
+        # re-map the biggest cluster to memory in order to refine
+        # Unfortunately if the cluster is *very scattered*, then most of the file
+        # may end up being loaded into memory anyways (1 pg = 4096 b, 1 fp = 256 b)
+        # so if the cluster is ~ 6.25 % of the data, assuming it is distributed randomly
+        # in id-space, most of the array will be loaded again.
         range_ = range(start_idx, end_idx)
         brc_init.fit(
             fps,
@@ -229,6 +236,7 @@ class _TreeMergingRound:
             merge_criterion="tolerance",
             tolerance=self.tolerance,
         )
+        # TODO: It is possible to use madvise here, similarly to fit_file()
         # Rebuild a tree, inserting all BitFeatures from the corresponding batch
         for buf_path, idx_path in batch_path_pairs:
             bufs, mol_idxs = _load_bufs_and_mol_idxs(buf_path, idx_path, self.use_mmap)

--- a/bblean/multiround.py
+++ b/bblean/multiround.py
@@ -171,7 +171,7 @@ class _InitialRound:
         if self.double_cluster_init:
             # Rebuild the tree again, reinserting the fps from the largest cluster
             tree.reset()
-            tree.set_merge(merge_criterion="tolernace", tolerance=self.tolerance)
+            tree.set_merge(merge_criterion="tolerance", tolerance=self.tolerance)
             for bufs, mol_idxs in zip(fps_bfs.values(), mols_bfs.values()):
                 tree._fit_np(bufs, reinsert_index_seqs=mol_idxs)
             fps_bfs, mols_bfs = tree._bf_to_np()

--- a/bblean/multiround.py
+++ b/bblean/multiround.py
@@ -110,15 +110,6 @@ def _chunk_file_pairs_in_batches(
     return batches
 
 
-def _load_bufs_and_mol_idxs(
-    buf_path: Path, idx_path: Path, use_mmap: bool = True
-) -> tuple[NDArray[tp.Any], tp.Any]:
-    bufs = np.load(buf_path, mmap_mode="r" if use_mmap else None)
-    with open(idx_path, "rb") as f:
-        mol_idxs = pickle.load(f)
-    return bufs, mol_idxs
-
-
 def _save_bufs_and_mol_idxs(
     out_dir: Path,
     fps_bfs: dict[str, tp.Any],
@@ -143,7 +134,6 @@ class _InitialRound:
         out_dir: Path | str,
         n_features: int | None = None,
         max_fps: int | None = None,
-        use_mmap: bool = True,
         merge_criterion: str = "diameter",
         input_is_packed: bool = True,
     ) -> None:
@@ -154,58 +144,39 @@ class _InitialRound:
         self.tolerance = tolerance
         self.out_dir = Path(out_dir)
         self.max_fps = max_fps
-        self.use_mmap = use_mmap
         self.merge_criterion = merge_criterion
         self.input_is_packed = input_is_packed
 
     def __call__(self, file_info: tuple[str, Path, int, int]) -> None:
         file_label, fp_file, start_idx, end_idx = file_info
-        fps = np.load(fp_file, mmap_mode="r" if self.use_mmap else None)[: self.max_fps]
 
         # First fit the fps in each process, in parallel.
         # `reinsert_indices` required to keep track of mol idxs in different processes.
-        brc_init = BitBirch(
+        tree = BitBirch(
             branching_factor=self.branching_factor,
             threshold=self.threshold,
             merge_criterion=self.merge_criterion,
         )
-        # TODO: It is possible to use madvise here, similarly to fit_file() It is
-        # *not easy* though. Maybe best would be to invalidate the mmap completely and
-        # re-map the biggest cluster to memory in order to refine
-        # Unfortunately if the cluster is *very scattered*, then most of the file
-        # may end up being loaded into memory anyways (1 pg = 4096 b, 1 fp = 256 b)
-        # so if the cluster is ~ 6.25 % of the data, assuming it is distributed randomly
-        # in id-space, most of the array will be loaded again.
         range_ = range(start_idx, end_idx)
-        brc_init.fit(
-            fps,
+        tree.fit(
+            fp_file,
             reinsert_indices=range_,
             n_features=self.n_features,
             input_is_packed=self.input_is_packed,
+            max_fps=self.max_fps,
         )
-        # Extract the BitFeatures of the leaves, breaking the largest cluster apart
-        fps_bfs, mols_bfs = brc_init._bf_to_np_refine(fps, initial_mol=start_idx)
-        del fps
-        del brc_init
-        gc.collect()
+        # Extract the BitFeatures of the leaves, breaking the largest cluster(s) apart
+        fps_bfs, mols_bfs = tree._bf_to_np_refine(fp_file, initial_mol=start_idx)
 
         if self.double_cluster_init:
             # Rebuild the tree again, reinserting the fps from the largest cluster
-            brc_tolerance = BitBirch(
-                branching_factor=self.branching_factor,
-                threshold=self.threshold,
-                merge_criterion="tolerance",
-                tolerance=self.tolerance,
-            )
+            tree.reset()
+            tree.set_merge(merge_criterion="tolernace", tolerance=self.tolerance)
             for bufs, mol_idxs in zip(fps_bfs.values(), mols_bfs.values()):
-                brc_tolerance._fit_np(
-                    bufs,
-                    reinsert_index_sequences=mol_idxs,
-                )
-            fps_bfs, mols_bfs = brc_tolerance._bf_to_np()
-            del brc_tolerance
-            gc.collect()
-
+                tree._fit_np(bufs, reinsert_index_seqs=mol_idxs)
+            fps_bfs, mols_bfs = tree._bf_to_np()
+        del tree
+        gc.collect()
         _save_bufs_and_mol_idxs(self.out_dir, fps_bfs, mols_bfs, file_label, 1)
 
 
@@ -217,7 +188,6 @@ class _TreeMergingRound:
         tolerance: float,
         round_idx: int,
         out_dir: Path | str,
-        use_mmap: bool = True,
         is_final: bool = False,
     ) -> None:
         self.branching_factor = branching_factor
@@ -225,41 +195,39 @@ class _TreeMergingRound:
         self.tolerance = tolerance
         self.round_idx = round_idx
         self.out_dir = Path(out_dir)
-        self.use_mmap = use_mmap
         self.is_final = is_final
 
     def __call__(self, batch_info: tuple[str, tp.Sequence[tuple[Path, Path]]]) -> None:
         batch_label, batch_path_pairs = batch_info
-        brc_merger = BitBirch(
+        tree = BitBirch(
             branching_factor=self.branching_factor,
             threshold=self.threshold,
             merge_criterion="tolerance",
             tolerance=self.tolerance,
         )
-        # TODO: It is possible to use madvise here, similarly to fit_file()
         # Rebuild a tree, inserting all BitFeatures from the corresponding batch
         for buf_path, idx_path in batch_path_pairs:
-            bufs, mol_idxs = _load_bufs_and_mol_idxs(buf_path, idx_path, self.use_mmap)
-            brc_merger._fit_np(bufs, reinsert_index_sequences=mol_idxs)
+            with open(idx_path, "rb") as f:
+                mol_idxs = pickle.load(f)
+            tree._fit_np(buf_path, reinsert_index_seqs=mol_idxs)
             del mol_idxs
-            del bufs
             gc.collect()
 
         # If this this is the final round save the clusters and exit
         # In this case self.round_idx and batch_label are unused
         if self.is_final:
-            cluster_mol_ids = brc_merger.get_cluster_mol_ids()
-            del brc_merger
+            cluster_mol_ids = tree.get_cluster_mol_ids()
+            del tree
             gc.collect()
             with open(self.out_dir / "clusters.pkl", mode="wb") as f:
                 pickle.dump(cluster_mol_ids, f)
             return
 
+        # TODO: A refinement step here would be a good idea
         # Otherwise fetch and save the bufs and idxs for the next round
-        fps_bfs, mols_bfs = brc_merger._bf_to_np()
-        del brc_merger
+        fps_bfs, mols_bfs = tree._bf_to_np()
+        del tree
         gc.collect()
-
         _save_bufs_and_mol_idxs(
             self.out_dir, fps_bfs, mols_bfs, batch_label, self.round_idx
         )
@@ -302,7 +270,6 @@ def run_multiround_bitbirch(
     # Advanced
     num_midsection_rounds: int = 1,
     bin_size: int = 10,
-    use_mmap: bool = DEFAULTS.use_mmap,
     max_tasks_per_process: int = 1,
     double_cluster_init: bool = True,
     # Debug
@@ -333,7 +300,6 @@ def run_multiround_bitbirch(
         branching_factor=branching_factor,
         threshold=threshold,
         tolerance=tolerance,
-        use_mmap=use_mmap,
         out_dir=out_dir,
     )
     timer = Timer()


### PR DESCRIPTION
Major improvement in memory efficiency, around ~40%, by using `madvise` to release memory held by the mmaped arrays.

In the future it would be a good idea to support pyarrow parquet format, this would make things significantly simpler.
